### PR TITLE
Upgrade package to support PHP 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Thumbs.db
 
 # IDE-relative files and folders
 .idea
+
+# phpunit coverage
+.phpunit.cache
+coverage.xml

--- a/Tests/SharedConfigurationTest.php
+++ b/Tests/SharedConfigurationTest.php
@@ -13,13 +13,13 @@ namespace Panda\Config\Tests;
 
 use Panda\Config\SharedConfiguration;
 use Panda\Registry\SharedRegistry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SharedConfigurationTest
  * @package Panda\Config\Tests
  */
-class SharedConfigurationTest extends PHPUnit_Framework_TestCase
+class SharedConfigurationTest extends TestCase
 {
     /**
      * @var SharedConfiguration
@@ -29,7 +29,7 @@ class SharedConfigurationTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "panda/registry": "^2.0"
+        "php": "^8.3",
+        "panda/registry": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~11.4"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10">
+    <testsuites>
+        <testsuite name="All Tests">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>./</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
### Key Updates
- `PHP` from 7.0 to 8.3
- `panda/registry` from 2.0 to 3.0
- `phpunit/phpunit` from 5.7 to 11.4

### Notable changed in this version
- Added `phpunit.xml` configuration file, which is required by the `phpunit` version `11.4` to run unit tests.
- Updated `composer.json` branch-alias from `2.0-dev` to `3.0-dev`